### PR TITLE
feat(plugin): add /slack-sessions:project slash command

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slack-sessions",
   "description": "Drive Claude Code from Slack. Each top-level message in DM spawns a fresh Claude session; in-thread replies resume that session via `claude --resume`. One thread = one transcript = no context rot across unrelated tasks.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Jeff Cosme",
     "email": "jeff@thinkingmachin.es"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "slack-sessions-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "slack-sessionsd"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "json5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["daemon", "cli"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 authors = ["Jeff Cosme <jeff@thinkingmachin.es>"]

--- a/commands/project.md
+++ b/commands/project.md
@@ -1,0 +1,19 @@
+---
+description: Manage the slack-sessions project registry used for `!start <name>` selection in Slack. Without args, lists registered projects. Subcommands: add <name> <path>, list, remove <name>, set-default <path>.
+allowed-tools:
+  - Bash(*/slack-sessions project*)
+argument-hint: "add|list|remove|set-default [name] [path]"
+---
+
+If `$ARGUMENTS` is empty, default to `list`:
+
+```bash
+ARGS="${ARGUMENTS:-list}"
+"${CLAUDE_PLUGIN_ROOT}/bin/slack-sessions" project $ARGS
+```
+
+Print the output verbatim. Reminders:
+
+- `add <name> <path>` registers a project so `!start <name> <prompt>` in Slack spawns a session in that directory. Path must exist.
+- `set-default <path>` sets the working directory used when a top-level Slack message has no `!start <name>` prefix.
+- `remove <name>` deletes a registered project; sessions already running are unaffected.


### PR DESCRIPTION
## Summary
- Adds `commands/project.md` mirroring the `slack-sessions project` CLI subcommand (`add` / `list` / `remove` / `set-default`) — every other CLI subcommand already had a slash equivalent; this one was missed.
- Bumps plugin manifest + Cargo workspace `0.1.1` → `0.1.2` so Claude Code's plugin cache invalidates and users pick up the new command on `/plugin marketplace update`.

Closes #1.

## Test plan
- [ ] `/plugin marketplace update slack-sessions` picks up `commands/project.md`
- [ ] `/slack-sessions:project` (no args) lists registered projects
- [ ] `/slack-sessions:project add demo ~/projects/demo` registers a project
- [ ] `/slack-sessions:project set-default ~/projects/demo` sets default cwd
- [ ] `/slack-sessions:project remove demo` removes it
- [ ] `slack-sessions --version` reports `0.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)